### PR TITLE
Add email credits

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -89,6 +89,7 @@ Client.prototype.request = function(_options, _callback)
 
             } else
             {
+                // Take email credits from response header and pass in body for checking the email credits
                 _body.emailcredits= _res.headers["x-checkmail-credits"];
                 _resolve(_body);
             }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -89,6 +89,7 @@ Client.prototype.request = function(_options, _callback)
 
             } else
             {
+                _body.emailcredits= _res.headers["x-checkmail-credits"];
                 _resolve(_body);
             }
         });


### PR DESCRIPTION
Checkmail email credits taken from checkmail verification API response header and pass it in response body so if anyone wants to perform a certain operation based on email credit then they can do it.

Example:

As checkmail.io paid user if my credit equal to 10 then my system notify me to purchase more credits.